### PR TITLE
Adding remarks for the configs and creating a combined configuration

### DIFF
--- a/ServerLess_TLSFrag_Xray_Config.json
+++ b/ServerLess_TLSFrag_Xray_Config.json
@@ -1,4 +1,5 @@
 {
+  "remarks": "GFW-knocker",
   "log": {
     "access": "",
     "error": "",
@@ -16,22 +17,15 @@
         "104.16.124.175",
         "104.16.248.249",
         "104.16.249.249",
-        "104.26.13.8"        
+        "104.26.13.8"
       ],
-      "domain:youtube.com": [
-        "google.com"
-      ]
+      "domain:youtube.com": ["google.com"]
     },
-    "servers": [
-      "https://cloudflare-dns.com/dns-query"
-    ]
+    "servers": ["https://cloudflare-dns.com/dns-query"]
   },
   "inbounds": [
     {
-      "domainOverride": [
-        "http",
-        "tls"
-      ],
+      "domainOverride": ["http", "tls"],
       "protocol": "socks",
       "tag": "socks-in",
       "listen": "127.0.0.1",
@@ -43,10 +37,7 @@
       },
       "sniffing": {
         "enabled": true,
-        "destOverride": [
-          "http",
-          "tls"
-        ]
+        "destOverride": ["http", "tls"]
       }
     },
     {
@@ -59,10 +50,7 @@
       },
       "sniffing": {
         "enabled": true,
-        "destOverride": [
-          "http",
-          "tls"
-        ]
+        "destOverride": ["http", "tls"]
       }
     }
   ],
@@ -73,10 +61,7 @@
       "domainStrategy": "UseIP",
       "sniffing": {
         "enabled": true,
-        "destOverride": [
-          "http",
-          "tls"
-        ]
+        "destOverride": ["http", "tls"]
       },
       "settings": {
         "fragment": {
@@ -124,10 +109,7 @@
         "security": "tls",
         "tlsSettings": {
           "allowInsecure": false,
-          "alpn": [
-            "h2",
-            "http/1.1"
-          ],
+          "alpn": ["h2", "http/1.1"],
           "fingerprint": "randomized",
           "publicKey": "",
           "serverName": "google.com",
@@ -166,20 +148,14 @@
     "domainStrategy": "IPIfNonMatch",
     "rules": [
       {
-        "inboundTag": [
-          "socks-in",
-          "http-in"
-        ],
+        "inboundTag": ["socks-in", "http-in"],
         "type": "field",
         "port": "53",
         "outboundTag": "dns-out",
         "enabled": true
       },
       {
-        "inboundTag": [
-          "socks-in",
-          "http-in"
-        ],
+        "inboundTag": ["socks-in", "http-in"],
         "type": "field",
         "port": "0-65535",
         "outboundTag": "fragment-out",

--- a/ServerLess_TLSFrag_Xray_Config_New.json
+++ b/ServerLess_TLSFrag_Xray_Config_New.json
@@ -1,4 +1,5 @@
 {
+  "remarks": "GFW-knocker",
   "log": {
     "access": "",
     "error": "",
@@ -16,22 +17,15 @@
         "104.16.124.175",
         "104.16.248.249",
         "104.16.249.249",
-        "104.26.13.8"        
+        "104.26.13.8"
       ],
-      "domain:youtube.com": [
-        "google.com"
-      ]
+      "domain:youtube.com": ["google.com"]
     },
-    "servers": [
-      "https://cloudflare-dns.com/dns-query"
-    ]
+    "servers": ["https://cloudflare-dns.com/dns-query"]
   },
   "inbounds": [
     {
-      "domainOverride": [
-        "http",
-        "tls"
-      ],
+      "domainOverride": ["http", "tls"],
       "protocol": "socks",
       "tag": "socks-in",
       "listen": "127.0.0.1",
@@ -43,10 +37,7 @@
       },
       "sniffing": {
         "enabled": true,
-        "destOverride": [
-          "http",
-          "tls"
-        ]
+        "destOverride": ["http", "tls"]
       }
     },
     {
@@ -59,10 +50,7 @@
       },
       "sniffing": {
         "enabled": true,
-        "destOverride": [
-          "http",
-          "tls"
-        ]
+        "destOverride": ["http", "tls"]
       }
     }
   ],
@@ -73,10 +61,7 @@
       "domainStrategy": "UseIP",
       "sniffing": {
         "enabled": true,
-        "destOverride": [
-          "http",
-          "tls"
-        ]
+        "destOverride": ["http", "tls"]
       },
       "settings": {
         "fragment": {
@@ -124,10 +109,7 @@
         "security": "tls",
         "tlsSettings": {
           "allowInsecure": false,
-          "alpn": [
-            "h2",
-            "http/1.1"
-          ],
+          "alpn": ["h2", "http/1.1"],
           "fingerprint": "randomized",
           "publicKey": "",
           "serverName": "google.com",
@@ -166,20 +148,14 @@
     "domainStrategy": "IPIfNonMatch",
     "rules": [
       {
-        "inboundTag": [
-          "socks-in",
-          "http-in"
-        ],
+        "inboundTag": ["socks-in", "http-in"],
         "type": "field",
         "port": "53",
         "outboundTag": "dns-out",
         "enabled": true
       },
       {
-        "inboundTag": [
-          "socks-in",
-          "http-in"
-        ],
+        "inboundTag": ["socks-in", "http-in"],
         "type": "field",
         "port": "0-65535",
         "outboundTag": "fragment-out",

--- a/multiple_config.json
+++ b/multiple_config.json
@@ -1,0 +1,426 @@
+[
+  {
+    "remarks": "GFW-knocker #1",
+    "log": {
+      "access": "",
+      "error": "",
+      "loglevel": "none",
+      "dnsLog": false
+    },
+    "dns": {
+      "tag": "dns",
+      "hosts": {
+        "cloudflare-dns.com": [
+          "172.67.73.38",
+          "104.19.155.92",
+          "172.67.73.163",
+          "104.18.155.42",
+          "104.16.124.175",
+          "104.16.248.249",
+          "104.16.249.249",
+          "104.26.13.8"
+        ],
+        "domain:youtube.com": ["google.com"]
+      },
+      "servers": ["https://cloudflare-dns.com/dns-query"]
+    },
+    "inbounds": [
+      {
+        "domainOverride": ["http", "tls"],
+        "protocol": "socks",
+        "tag": "socks-in",
+        "listen": "127.0.0.1",
+        "port": 10808,
+        "settings": {
+          "auth": "noauth",
+          "udp": true,
+          "userLevel": 8
+        },
+        "sniffing": {
+          "enabled": true,
+          "destOverride": ["http", "tls"]
+        }
+      },
+      {
+        "protocol": "http",
+        "tag": "http-in",
+        "listen": "127.0.0.1",
+        "port": 10809,
+        "settings": {
+          "userLevel": 8
+        },
+        "sniffing": {
+          "enabled": true,
+          "destOverride": ["http", "tls"]
+        }
+      }
+    ],
+    "outbounds": [
+      {
+        "protocol": "freedom",
+        "tag": "fragment-out",
+        "domainStrategy": "UseIP",
+        "sniffing": {
+          "enabled": true,
+          "destOverride": ["http", "tls"]
+        },
+        "settings": {
+          "fragment": {
+            "packets": "tlshello",
+            "length": "10-20",
+            "interval": "10-20"
+          }
+        },
+        "streamSettings": {
+          "sockopt": {
+            "tcpNoDelay": true,
+            "tcpKeepAliveIdle": 100,
+            "mark": 255,
+            "domainStrategy": "UseIP"
+          }
+        }
+      },
+      {
+        "protocol": "dns",
+        "tag": "dns-out"
+      },
+      {
+        "protocol": "vless",
+        "tag": "fakeproxy-out",
+        "domainStrategy": "",
+        "settings": {
+          "vnext": [
+            {
+              "address": "google.com",
+              "port": 443,
+              "users": [
+                {
+                  "encryption": "none",
+                  "flow": "",
+                  "id": "UUID",
+                  "level": 8,
+                  "security": "auto"
+                }
+              ]
+            }
+          ]
+        },
+        "streamSettings": {
+          "network": "ws",
+          "security": "tls",
+          "tlsSettings": {
+            "allowInsecure": false,
+            "alpn": ["h2", "http/1.1"],
+            "fingerprint": "randomized",
+            "publicKey": "",
+            "serverName": "google.com",
+            "shortId": "",
+            "show": false,
+            "spiderX": ""
+          },
+          "wsSettings": {
+            "headers": {
+              "Host": "google.com"
+            },
+            "path": "/"
+          }
+        },
+        "mux": {
+          "concurrency": 8,
+          "enabled": false
+        }
+      }
+    ],
+    "policy": {
+      "levels": {
+        "8": {
+          "connIdle": 300,
+          "downlinkOnly": 1,
+          "handshake": 4,
+          "uplinkOnly": 1
+        }
+      },
+      "system": {
+        "statsOutboundUplink": true,
+        "statsOutboundDownlink": true
+      }
+    },
+    "routing": {
+      "domainStrategy": "IPIfNonMatch",
+      "rules": [
+        {
+          "inboundTag": ["socks-in", "http-in"],
+          "type": "field",
+          "port": "53",
+          "outboundTag": "dns-out",
+          "enabled": true
+        },
+        {
+          "inboundTag": ["socks-in", "http-in"],
+          "type": "field",
+          "port": "0-65535",
+          "outboundTag": "fragment-out",
+          "enabled": true
+        }
+      ],
+      "strategy": "rules"
+    },
+    "stats": {}
+  },
+  {
+    "remarks": "GFW-knocker #2",
+    "log": {
+      "access": "",
+      "error": "",
+      "loglevel": "none",
+      "dnsLog": false
+    },
+    "dns": {
+      "tag": "dns",
+      "hosts": {
+        "cloudflare-dns.com": [
+          "172.67.73.38",
+          "104.19.155.92",
+          "172.67.73.163",
+          "104.18.155.42",
+          "104.16.124.175",
+          "104.16.248.249",
+          "104.16.249.249",
+          "104.26.13.8"
+        ],
+        "domain:youtube.com": ["google.com"]
+      },
+      "servers": ["https://cloudflare-dns.com/dns-query"]
+    },
+    "inbounds": [
+      {
+        "domainOverride": ["http", "tls"],
+        "protocol": "socks",
+        "tag": "socks-in",
+        "listen": "127.0.0.1",
+        "port": 10808,
+        "settings": {
+          "auth": "noauth",
+          "udp": true,
+          "userLevel": 8
+        },
+        "sniffing": {
+          "enabled": true,
+          "destOverride": ["http", "tls"]
+        }
+      },
+      {
+        "protocol": "http",
+        "tag": "http-in",
+        "listen": "127.0.0.1",
+        "port": 10809,
+        "settings": {
+          "userLevel": 8
+        },
+        "sniffing": {
+          "enabled": true,
+          "destOverride": ["http", "tls"]
+        }
+      }
+    ],
+    "outbounds": [
+      {
+        "protocol": "freedom",
+        "tag": "fragment-out",
+        "domainStrategy": "UseIP",
+        "sniffing": {
+          "enabled": true,
+          "destOverride": ["http", "tls"]
+        },
+        "settings": {
+          "fragment": {
+            "packets": "1-1",
+            "length": "1-3",
+            "interval": "5-10"
+          }
+        },
+        "streamSettings": {
+          "sockopt": {
+            "tcpNoDelay": true,
+            "tcpKeepAliveIdle": 100,
+            "mark": 255,
+            "domainStrategy": "UseIP"
+          }
+        }
+      },
+      {
+        "protocol": "dns",
+        "tag": "dns-out"
+      },
+      {
+        "protocol": "vless",
+        "tag": "fakeproxy-out",
+        "domainStrategy": "",
+        "settings": {
+          "vnext": [
+            {
+              "address": "google.com",
+              "port": 443,
+              "users": [
+                {
+                  "encryption": "none",
+                  "flow": "",
+                  "id": "UUID",
+                  "level": 8,
+                  "security": "auto"
+                }
+              ]
+            }
+          ]
+        },
+        "streamSettings": {
+          "network": "ws",
+          "security": "tls",
+          "tlsSettings": {
+            "allowInsecure": false,
+            "alpn": ["h2", "http/1.1"],
+            "fingerprint": "randomized",
+            "publicKey": "",
+            "serverName": "google.com",
+            "shortId": "",
+            "show": false,
+            "spiderX": ""
+          },
+          "wsSettings": {
+            "headers": {
+              "Host": "google.com"
+            },
+            "path": "/"
+          }
+        },
+        "mux": {
+          "concurrency": 8,
+          "enabled": false
+        }
+      }
+    ],
+    "policy": {
+      "levels": {
+        "8": {
+          "connIdle": 300,
+          "downlinkOnly": 1,
+          "handshake": 4,
+          "uplinkOnly": 1
+        }
+      },
+      "system": {
+        "statsOutboundUplink": true,
+        "statsOutboundDownlink": true
+      }
+    },
+    "routing": {
+      "domainStrategy": "IPIfNonMatch",
+      "rules": [
+        {
+          "inboundTag": ["socks-in", "http-in"],
+          "type": "field",
+          "port": "53",
+          "outboundTag": "dns-out",
+          "enabled": true
+        },
+        {
+          "inboundTag": ["socks-in", "http-in"],
+          "type": "field",
+          "port": "0-65535",
+          "outboundTag": "fragment-out",
+          "enabled": true
+        }
+      ],
+      "strategy": "rules"
+    },
+    "stats": {}
+  },
+  {
+    "remarks": "GFW-knocker #3",
+    "log": {
+      "access": "",
+      "error": "",
+      "loglevel": "warning"
+    },
+    "inbounds": [
+      {
+        "tag": "socks",
+        "port": 10808,
+        "listen": "127.0.0.1",
+        "protocol": "socks",
+        "sniffing": {
+          "enabled": true,
+          "destOverride": ["http", "tls"]
+        },
+        "settings": {
+          "auth": "noauth",
+          "udp": true,
+          "allowTransparent": false
+        }
+      },
+      {
+        "tag": "http",
+        "port": 10809,
+        "listen": "127.0.0.1",
+        "protocol": "http",
+        "sniffing": {
+          "enabled": true,
+          "destOverride": ["http", "tls"]
+        },
+        "settings": {
+          "auth": "noauth",
+          "udp": true,
+          "allowTransparent": false
+        }
+      }
+    ],
+    "outbounds": [
+      {
+        "tag": "pyprox",
+        "protocol": "http",
+        "settings": {
+          "servers": [
+            {
+              "address": "127.0.0.1",
+              "port": 4500
+            }
+          ]
+        }
+      },
+
+      {
+        "tag": "direct",
+        "protocol": "freedom",
+        "settings": {}
+      },
+
+      {
+        "tag": "block",
+        "protocol": "blackhole",
+        "settings": {
+          "response": {
+            "type": "http"
+          }
+        }
+      }
+    ],
+    "routing": {
+      "domainStrategy": "IPIfNonMatch",
+      "rules": [
+        {
+          "type": "field",
+          "inboundTag": ["api"],
+          "outboundTag": "api",
+          "enabled": true
+        },
+
+        {
+          "type": "field",
+          "port": "0-65535",
+          "outboundTag": "pyprox",
+          "enabled": true
+        }
+      ]
+    }
+  }
+]

--- a/v2ray_HTTPS_config.json
+++ b/v2ray_HTTPS_config.json
@@ -1,4 +1,5 @@
 {
+  "remarks": "GFW-knocker",
   "log": {
     "access": "",
     "error": "",
@@ -13,10 +14,7 @@
       "protocol": "socks",
       "sniffing": {
         "enabled": true,
-        "destOverride": [
-          "http",
-          "tls"
-        ]
+        "destOverride": ["http", "tls"]
       },
       "settings": {
         "auth": "noauth",
@@ -31,10 +29,7 @@
       "protocol": "http",
       "sniffing": {
         "enabled": true,
-        "destOverride": [
-          "http",
-          "tls"
-        ]
+        "destOverride": ["http", "tls"]
       },
       "settings": {
         "auth": "noauth",
@@ -44,9 +39,6 @@
     }
   ],
 
-
-
-
   "outbounds": [
     {
       "tag": "pyprox",
@@ -55,17 +47,17 @@
         "servers": [
           {
             "address": "127.0.0.1",
-            "port": 4500            
+            "port": 4500
           }
         ]
-      }      
+      }
     },
 
     {
       "tag": "direct",
       "protocol": "freedom",
       "settings": {}
-    },    
+    },
 
     {
       "tag": "block",
@@ -76,21 +68,14 @@
         }
       }
     }
-
-
   ],
 
-
-
   "routing": {
-
     "domainStrategy": "IPIfNonMatch",
     "rules": [
       {
         "type": "field",
-        "inboundTag": [
-          "api"
-        ],
+        "inboundTag": ["api"],
         "outboundTag": "api",
         "enabled": true
       },
@@ -101,8 +86,6 @@
         "outboundTag": "pyprox",
         "enabled": true
       }
-
-
     ]
   }
 }


### PR DESCRIPTION
Description of the changes made:

1. In this PR, `remarks` have been enabled for the three existing configurations to prevent them from being displayed on the user's device with the name `:0`.  
2. Additionally, a combined configuration has been added to encapsulate all three previous configurations into a single sub-link.